### PR TITLE
Add scripts block placeholder

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -14,5 +14,8 @@
 
 
     {% endblock %}
+
+    {% block scripts %}
+    {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow child templates to inject JavaScript by adding a `scripts` block in the base template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851cb72c8b0832e8f0b131a498d581b