### PR TITLE
Add CSRF protection

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,14 @@
-from flask import Flask
+from flask import Flask, render_template
 from flask_login import LoginManager
+from flask_wtf import CSRFProtect
 from views.auth.routes import auth_bp
 from views.main.routes import main_bp
 from views.admin.routes import admin_bp
-from flask_login import LoginManager
 from models import User
 from models import db
 from flask_migrate import Migrate, upgrade
-from flask import Flask, render_template
+
+csrf = CSRFProtect()
 
 
 
@@ -15,6 +16,8 @@ from flask import Flask, render_template
 def create_app():
     app = Flask(__name__)
     app.config.from_object('config.Config')
+
+    csrf.init_app(app)
 
 
 

--- a/views/admin/routes.py
+++ b/views/admin/routes.py
@@ -1,8 +1,8 @@
 from . import admin_bp
-from flask import render_template, redirect, url_for, flash, request, current_app
+from flask import render_template, redirect, url_for, flash, request, current_app, abort
 from flask_login import login_required, current_user
 from models import db, User, Group
-from forms import GroupForm  # import CheckoutLimitForm when ready
+from forms import GroupForm, CSRFProtectForm  # import CheckoutLimitForm when ready
 from utililties.decorators import roles_required
 
 
@@ -78,6 +78,10 @@ def edit_group(group_id):
 @roles_required('Admin')
 @login_required
 def delete_group(group_id):
+    form = CSRFProtectForm()
+    if not form.validate_on_submit():
+        abort(400)
+
     # user = current_user
     group = Group.query.get_or_404(group_id)
     db.session.delete(group)
@@ -104,5 +108,9 @@ def configure_checkout_limit():
     #     flash(f'Checkout limit set to {new_limit}', 'success')
     #     return redirect(url_for('admin.list_groups'))
     # return render_template('checkout_limit_form.html', form=form)
+    form = CSRFProtectForm()
+    if request.method == 'POST' and not form.validate_on_submit():
+        abort(400)
+
     flash('Checkout limit configuration placeholder.', 'info')
     return redirect(url_for('admin.list_groups'))

--- a/views/main/routes.py
+++ b/views/main/routes.py
@@ -34,6 +34,10 @@ def dashboard():
 @login_required
 def add_to_basket():
     """AJAX endpoint to add a group to basket."""
+    form = CSRFProtectForm()
+    if not form.validate_on_submit():
+        return jsonify({'success': False, 'message': 'Invalid CSRF token.'}), 400
+
     user = current_user
     group_id = request.json.get('group_id') or request.form.get('group_id')
     if not group_id:
@@ -75,6 +79,10 @@ def add_to_basket():
 @login_required
 def remove_from_basket():
     """AJAX endpoint to remove a group from basket."""
+    form = CSRFProtectForm()
+    if not form.validate_on_submit():
+        return jsonify({'success': False, 'message': 'Invalid CSRF token.'}), 400
+
     user = current_user
     group_id = request.json.get('group_id') or request.form.get('group_id')
     if not group_id:
@@ -99,6 +107,8 @@ def checkout():
 
     form = CSRFProtectForm()
     if request.method == 'POST':
+        if not form.validate_on_submit():
+            return jsonify({'success': False, 'message': 'Invalid CSRF token.'}), 400
 
         limit = current_app.config.get('GROUP_CHECKOUT_LIMIT', 3)
         if len(user.purchased_items) + len(basket_items) > limit:
@@ -133,6 +143,9 @@ def checkout():
 @login_required
 def remove_from_checkout():
     """AJAX endpoint to remove a group while on the checkout page."""
+    form = CSRFProtectForm()
+    if not form.validate_on_submit():
+        return jsonify({'success': False, 'message': 'Invalid CSRF token.'}), 400
 
     user = current_user
     group_id = request.json.get('group_id') or request.form.get('group_id')
@@ -164,6 +177,8 @@ def send_group_links():
     """Send purchased group links via email (placeholder)."""
     print("⭐ Sending group links via email... Current user:", current_user.email)
     form = CSRFProtectForm()
+    if not form.validate_on_submit():
+        return jsonify({'success': False, 'message': 'Invalid CSRF token.'}), 400
 
     links = _generate_group_links()
 


### PR DESCRIPTION
## Summary
- enable CSRF protection globally with `CSRFProtect`
- enforce CSRF validation on AJAX and admin POST routes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851d8701e24832e90b96c7075696160