### PR TITLE
Add invite link tokens

### DIFF
--- a/models.py
+++ b/models.py
@@ -103,3 +103,19 @@ class PurchasedItem(db.Model):
 
     def __repr__(self):
         return f"<PurchasedItem {self.id} User:{self.user_id} Group:{self.group_id}>"
+
+
+class InviteToken(db.Model):
+    """Temporary token granting access to a group."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    group_id = db.Column(db.Integer, db.ForeignKey('group.id'), nullable=False)
+    token = db.Column(db.String(64), unique=True, nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    user = db.relationship('User', backref='invite_tokens', lazy=True)
+    group = db.relationship('Group', backref='invite_tokens', lazy=True)
+
+    def __repr__(self):
+        return f"<InviteToken {self.token} User:{self.user_id} Group:{self.group_id}>"


### PR DESCRIPTION
## Summary
- create `InviteToken` database model
- generate invite tokens when checking out groups
- provide helper to return invite URLs instead of direct group links
- add `/join/<token>` route to validate and redirect

## Testing
- `python -m py_compile models.py views/main/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d8d361cc832e8006d35c05aadcc2