### PR TITLE
Fix checkout fetch credentials

### DIFF
--- a/static/js/checkout.js
+++ b/static/js/checkout.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'Content-Type': 'application/json',
         'X-CSRFToken': csrfToken
       },
+      credentials: 'same-origin',
       body: JSON.stringify({ group_id: gid })
     })
     .then(res => res.json())
@@ -42,7 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFToken': csrfToken
-      }
+      },
+      credentials: 'same-origin'
     })
     .then(res => res.json())
     .then(data => {


### PR DESCRIPTION
## Summary
- include `credentials: 'same-origin'` in checkout `fetch` calls so that CSRF token and session cookie are properly paired

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658b99e644832eb9b4ac7c1678c7b8